### PR TITLE
"Deploying smart gateways" is an actual procedure now

### DIFF
--- a/doc-Service-Assurance-Framework/assemblies/assembly_connecting-multiple-clouds-to-saf.adoc
+++ b/doc-Service-Assurance-Framework/assemblies/assembly_connecting-multiple-clouds-to-saf.adoc
@@ -39,6 +39,7 @@
 include::../modules/proc_configuring-multiple-clouds.adoc[leveloffset=+1]
 include::../modules/proc_planning-amqp-address-prefixes.adoc[leveloffset=+1]
 include::../modules/proc_deploying-smart-gateways.adoc[leveloffset=+1]
+include::../modules/ref_example-manifests.adoc[leveloffset=+2]
 include::../modules/proc_updating-collectd-configuration.adoc[leveloffset=+1]
 include::../modules/proc_querying-metrics-data-from-multiple-clouds.adoc[leveloffset=+1]
 include::../modules/proc_using-the-amq-interconnect-message-bus.adoc[leveloffset=+1]

--- a/doc-Service-Assurance-Framework/modules/proc_configuring-multiple-clouds.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_configuring-multiple-clouds.adoc
@@ -28,7 +28,7 @@ To configure multiple OpenStack clouds to target a single instance of {projectsh
 . Plan the AMQP address prefixes to use for each cloud. For more information, see <<planning-amqp-address-prefixes_connecting-multiple-clouds-to-saf>>.
 . Deploy metrics and events consumer Smart Gateways for each cloud to listen on
  the corresponding address prefixes. For more information, see <<deploying-smart-gateways_connecting-multiple-clouds-to-saf>>.
-. (Optionally) Delete the default Smart Gateways if they are no longer needed, see <<deleting-the-default-smart-gateways_connecting-multiple-clouds-to-saf>>.
+. (Optional) Delete the default Smart Gateways if they are no longer needed, see <<deleting-the-default-smart-gateways_connecting-multiple-clouds-to-saf>>.
 . Configure each cloud to send its metrics and events to SAF on the
  correct address. For more information, see <<updating-collectd-configuration_connecting-multiple-clouds-to-saf>>.
 

--- a/doc-Service-Assurance-Framework/modules/proc_configuring-multiple-clouds.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_configuring-multiple-clouds.adoc
@@ -28,6 +28,7 @@ To configure multiple OpenStack clouds to target a single instance of {projectsh
 . Plan the AMQP address prefixes to use for each cloud. For more information, see <<planning-amqp-address-prefixes_connecting-multiple-clouds-to-saf>>.
 . Deploy metrics and events consumer Smart Gateways for each cloud to listen on
  the corresponding address prefixes. For more information, see <<deploying-smart-gateways_connecting-multiple-clouds-to-saf>>.
+. (Optionally) Delete the default Smart Gateways if they are no longer needed, see <<deleting-the-default-smart-gateways_connecting-multiple-clouds-to-saf>>.
 . Configure each cloud to send its metrics and events to SAF on the
  correct address. For more information, see <<updating-collectd-configuration_connecting-multiple-clouds-to-saf>>.
 

--- a/doc-Service-Assurance-Framework/modules/proc_deleting-the-default-smart-gateways.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_deleting-the-default-smart-gateways.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+// This module can be included from assemblies using the following include statement:
+// include::<path>/proc_deleting-the-default-smart-gateways.adoc[leveloffset=+1]
+
+// The file name and the ID are based on the module title. For example:
+// * file name: proc_doing-procedure-a.adoc
+// * ID: [id='proc_doing-procedure-a_{context}']
+// * Title: = Doing procedure A
+//
+// The ID is used as an anchor for linking to the module. Avoid changing
+// it after the module has been published to ensure existing links are not
+// broken.
+//
+// The `context` attribute enables module reuse. Every module's ID includes
+// {context}, which ensures that the module has a unique ID even if it is
+// reused multiple times in a guide.
+//
+// Start the title with a verb, such as Creating or Create. See also
+// _Wording of headings_ in _The IBM Style Guide_.
+[id="deleting-the-default-smart-gateways_{context}"]
+= Deleting the default Smart Gateways
+
+Once you have configured SAF for multiple clouds, you may want to delete the
+default Smart Gateways if they are no longer in use.
+
+The steps are:
+
+. Delete default Smart Gateways from the cluster.
++
+----
+oc delete smartgateway cloud1-notify cloud1-telemetry
+----
+. (Optionally) Delete the default manifests
++
+----
+rm deploy/service-assurance/smartgateway/{events,metrics}-smartgateway.yaml
+----
+[NOTE]
+The default manifests will be regenerated if you re-run the <<generating-the-manifests-for-saf_installing-the-core-components-of-saf,Generating the manifests for SAF>> step.

--- a/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -23,22 +23,15 @@
 [id="deploying-smart-gateways_{context}"]
 = Deploying Smart Gateways
 
-You must deploy two Smart Gateways for each cloud; one for metrics and one for
-events. Configure both Smart Gateways to listen on the AMQP address defined for
-the corresponding cloud.
+You must deploy two Smart Gateways for each cloud; one for metrics and one for events. Configure both Smart Gateways to listen on the AMQP address defined for the corresponding cloud.
 
-When SAF is first deployed, two Smart Gateway manifests are created that define
-the two initial Smart Gateways for a single cloud,
-`deploy/service-assurance/smartgateway/metrics-smartgateway.yaml` and
-`deploy/service-assurance/smartgateway/events-smartgateway.yaml`. When deploying
- multiple Smart Gateways, these need to be adjusted to define the Smart Gateways
-handling the metrics and the events data for each cloud.
+When you deploy SAF for the first time, two Smart Gateway manifests are created that define the two initial Smart Gateways for a single cloud. When you deploy  multiple Smart Gateways, you must edit these manifests to define the Smart Gateways handling the metrics and the events data for each cloud.
 
-The steps are:
+To deploy multiple Smart Gateways, complete the following steps:
 
-. Edit the Smart Gateway manifests to define a Smart Gateway for each cloud (see
-example minifests below).
-. Delete existing Smart Gateways from the cluster.
+. Edit the following Smart Gateway manifests to define a Smart Gateway for each cloud: `deploy/service-assurance/smartgateway/metrics-smartgateway.yaml` and `deploy/service-assurance/smartgateway/events-smartgateway.yaml`. For more information, see
+<<example-manifests_connecting-multiple-clouds-to-saf>>.
+. Delete the existing Smart Gateways from the cluster.
 +
 ----
 oc delete smartgateway --all
@@ -48,88 +41,9 @@ oc delete smartgateway --all
 ----
 oc create -f deploy/service-assurance/smartgateway/
 ----
-. Verify that each Smart Gateway is Running (this can take a couple minutes
-depending on the number of Smart Gateways).
+. Verify that each Smart Gateway is running. This can take several minutes
+depending on the number of Smart Gateways.
 +
 ----
 oc get po -l app=smart-gateway
-----
-
-== Example Manifests
-
-[IMPORTANT]
-These are examples only. The content of these files may be different in your
-deployment, and if so you should copy those manifests, not these ones.
-
-You must ensure the `name` and `amqp_url` parameters of each Smart Gateway match
-the names you want to use for your clouds. For more information, see
-<<planning-amqp-address-prefixes_connecting-multiple-clouds-to-saf>>.
-
-
-metrics-smartgateway.yaml
-[source, yaml]
-----
-apiVersion: smartgateway.infra.watch/v1alpha1
-kind: SmartGateway
-metadata:
-  name: cloud1-telemetry
-spec:
-  size: 1
-  amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud1-telemetry
-  debug: "false"
-  container_image_path: "docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest"
-  service_type: "metrics"
-
----
-apiVersion: smartgateway.infra.watch/v1alpha1
-kind: SmartGateway
-metadata:
-  name: cloud2-telemetry
-spec:
-  size: 1
-  amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud2-telemetry
-  debug: "false"
-  container_image_path: "docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest"
-  service_type: "metrics"
-
-----
-
-events-smartgateway.yaml
-[source, yaml]
-----
----
-apiVersion: smartgateway.infra.watch/v1alpha1
-kind: SmartGateway
-metadata:
-  name: cloud1-notify
-spec:
-  size: 1
-  amqp_url: "qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud1-notify"
-  service_type: events
-  debug: "false"
-  elastic_url: "https://elasticsearch.sa-telemetry.svc:9200"
-  container_image_path: docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest
-  use_tls: "true"
-  tls_client_cert: /config/certs/admin-cert
-  tls_client_key: /config/certs/admin-key
-  tls_ca_cert: /config/certs/admin-ca
-  reset_index: "true"
-
----
-apiVersion: smartgateway.infra.watch/v1alpha1
-kind: SmartGateway
-metadata:
-  name: cloud2-notify
-spec:
-  size: 1
-  amqp_url: "qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud2-notify"
-  service_type: events
-  debug: "false"
-  elastic_url: "https://elasticsearch.sa-telemetry.svc:9200"
-  container_image_path: docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest
-  use_tls: "true"
-  tls_client_cert: /config/certs/admin-cert
-  tls_client_key: /config/certs/admin-key
-  tls_ca_cert: /config/certs/admin-ca
-  reset_index: "true"
 ----

--- a/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -21,35 +21,35 @@
 // Start the title with a verb, such as Creating or Create. See also
 // _Wording of headings_ in _The IBM Style Guide_.
 [id="deploying-smart-gateways_{context}"]
-= Deploying smart gateways
+= Deploying Smart Gateways
 
-You must deploy two smart gateways for each cloud; one for metrics and one for
-events, and both smart gateways must be configured to listen on the correct AMQP
-address.
+You must deploy two Smart Gateways for each cloud; one for metrics and one for
+events. Configure both Smart Gateways to listen on the AMQP address defined for
+the corresponding cloud.
 
-When SAF is first deployed, two smart gateway manifests are created that define
-the two initial smart gateways for a single cloud,
+When SAF is first deployed, two Smart Gateway manifests are created that define
+the two initial Smart Gateways for a single cloud,
 `deploy/service-assurance/smartgateway/metrics-smartgateway.yaml` and
 `deploy/service-assurance/smartgateway/events-smartgateway.yaml`. When deploying
- multiple smart gateways, these need to be adjusted to define metrics and events
-  smart gateways for each cloud.
+ multiple Smart Gateways, these need to be adjusted to define the Smart Gateways
+handling the metrics and the events data for each cloud.
 
 The steps are:
 
-. Edit the smart gateway manifests to define a smart gateway for each cloud (see
+. Edit the Smart Gateway manifests to define a Smart Gateway for each cloud (see
 example minifests below).
-. Delete existing smart gateways from the cluster.
+. Delete existing Smart Gateways from the cluster.
 +
 ----
 oc delete smartgateway --all
 ----
-. Deploy your new smart gateways.
+. Deploy your new Smart Gateways.
 +
 ----
 oc create -f deploy/service-assurance/smartgateway/
 ----
-. Verify that each smart gateway is Running (this can take a couple minutes
-depending on the number of smart gateways).
+. Verify that each Smart Gateway is Running (this can take a couple minutes
+depending on the number of Smart Gateways).
 +
 ----
 oc get po -l app=smart-gateway
@@ -58,12 +58,12 @@ oc get po -l app=smart-gateway
 == Example Manifests
 
 [IMPORTANT]
-These are examples only, the content of these files may be different in your
+These are examples only. The content of these files may be different in your
 deployment, and if so you should copy those manifests, not these ones.
 
-You must ensure the name and amqp_url parameters of each smart gateway match the
-names you want to use for your clouds. For more information, see
- <<planning-amqp-address-prefixes_connecting-multiple-clouds-to-saf>>.
+You must ensure the `name` and `amqp_url` parameters of each Smart Gateway match
+the names you want to use for your clouds. For more information, see
+<<planning-amqp-address-prefixes_connecting-multiple-clouds-to-saf>>.
 
 
 metrics-smartgateway.yaml

--- a/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -23,41 +23,113 @@
 [id="deploying-smart-gateways_{context}"]
 = Deploying smart gateways
 
-You must deploy two smart gateways for each cloud; one for metrics and one for events. Configure both smart gateways to listen on the correct AMQP address.  For example:
+You must deploy two smart gateways for each cloud; one for metrics and one for
+events, and both smart gateways must be configured to listen on the correct AMQP
+address.
 
+When SAF is first deployed, two smart gateway manifests are created that define
+the two initial smart gateways for a single cloud,
+`deploy/service-assurance/smartgateway/metrics-smartgateway.yaml` and
+`deploy/service-assurance/smartgateway/events-smartgateway.yaml`. When deploying
+ multiple smart gateways, these need to be adjusted to define metrics and events
+  smart gateways for each cloud.
+
+The steps are:
+
+. Edit the smart gateway manifests to define a smart gateway for each cloud (see
+example minifests below).
+. Delete existing smart gateways from the cluster.
++
+----
+oc delete smartgateway --all
+----
+. Deploy your new smart gateways.
++
+----
+oc create -f deploy/service-assurance/smartgateway/
+----
+. Verify that each smart gateway is Running (this can take a couple minutes
+depending on the number of smart gateways).
++
+----
+oc get po -l app=smart-gateway
+----
+
+== Example Manifests
+
+[IMPORTANT]
+These are examples only, the content of these files may be different in your
+deployment, and if so you should copy those manifests, not these ones.
+
+You must ensure the name and amqp_url parameters of each smart gateway match the
+names you want to use for your clouds. For more information, see
+ <<planning-amqp-address-prefixes_connecting-multiple-clouds-to-saf>>.
+
+
+metrics-smartgateway.yaml
+[source, yaml]
 ----
 apiVersion: smartgateway.infra.watch/v1alpha1
 kind: SmartGateway
 metadata:
- name: cloud1-telemetry
+  name: cloud1-telemetry
 spec:
- amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud1-telemetry
- serviceType: metrics
+  size: 1
+  amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud1-telemetry
+  debug: "false"
+  container_image_path: "docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest"
+  service_type: "metrics"
 
 ---
 apiVersion: smartgateway.infra.watch/v1alpha1
 kind: SmartGateway
 metadata:
- name: cloud1-notify
+  name: cloud2-telemetry
 spec:
- amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud1-notify
- serviceType: events
+  size: 1
+  amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud2-telemetry
+  debug: "false"
+  container_image_path: "docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest"
+  service_type: "metrics"
+
+----
+
+events-smartgateway.yaml
+[source, yaml]
+----
+---
+apiVersion: smartgateway.infra.watch/v1alpha1
+kind: SmartGateway
+metadata:
+  name: cloud1-notify
+spec:
+  size: 1
+  amqp_url: "qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud1-notify"
+  service_type: events
+  debug: "false"
+  elastic_url: "https://elasticsearch.sa-telemetry.svc:9200"
+  container_image_path: docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest
+  use_tls: "true"
+  tls_client_cert: /config/certs/admin-cert
+  tls_client_key: /config/certs/admin-key
+  tls_ca_cert: /config/certs/admin-ca
+  reset_index: "true"
 
 ---
 apiVersion: smartgateway.infra.watch/v1alpha1
 kind: SmartGateway
 metadata:
- name: cloud2-telemetry
+  name: cloud2-notify
 spec:
- amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud2-telemetry
- serviceType: metrics
-
----
-apiVersion: smartgateway.infra.watch/v1alpha1
-kind: SmartGateway
-metadata:
- name: cloud2-notify
-spec:
- amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud2-notify
- serviceType: events
+  size: 1
+  amqp_url: "qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud2-notify"
+  service_type: events
+  debug: "false"
+  elastic_url: "https://elasticsearch.sa-telemetry.svc:9200"
+  container_image_path: docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest
+  use_tls: "true"
+  tls_client_cert: /config/certs/admin-cert
+  tls_client_key: /config/certs/admin-key
+  tls_ca_cert: /config/certs/admin-ca
+  reset_index: "true"
 ----

--- a/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -29,13 +29,16 @@ When you deploy SAF for the first time, two Smart Gateway manifests are created 
 
 To deploy multiple Smart Gateways, complete the following steps:
 
-. Edit the following Smart Gateway manifests to define a Smart Gateway for each cloud: `deploy/service-assurance/smartgateway/metrics-smartgateway.yaml` and `deploy/service-assurance/smartgateway/events-smartgateway.yaml`. For more information, see
-<<example-manifests_connecting-multiple-clouds-to-saf>>.
-. Delete the existing Smart Gateways from the cluster.
+. Copy the following Smart Gateway manifests and edit them to define a Smart Gateway for each cloud: `deploy/service-assurance/smartgateway/metrics-smartgateway.yaml` and `deploy/service-assurance/smartgateway/events-smartgateway.yaml`. For more information, see <<example-manifests_connecting-multiple-clouds-to-saf>>.
 +
 ----
-oc delete smartgateway --all
+pushd deploy/service-assurance/smartgateway/
+cp events-smartgateway.yaml events-smartgateway-multicloud.yaml
+cp metrics-smartgateway.yaml metrics-smartgateway-multicloud.yaml
+vi events-smartgateway-multicloud.yaml metrics-smartgateway-multicloud.yaml
+popd
 ----
+
 . Deploy your new Smart Gateways.
 +
 ----

--- a/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_deploying-smart-gateways.adoc
@@ -25,7 +25,7 @@
 
 You must deploy two Smart Gateways for each cloud; one for metrics and one for events. Configure both Smart Gateways to listen on the AMQP address defined for the corresponding cloud.
 
-When you deploy SAF for the first time, two Smart Gateway manifests are created that define the two initial Smart Gateways for a single cloud. When you deploy  multiple Smart Gateways, you must edit these manifests to define the Smart Gateways handling the metrics and the events data for each cloud.
+When you deploy SAF for the first time, two Smart Gateway manifests are created that define the two initial Smart Gateways for a single cloud. When you deploy multiple Smart Gateways, you must edit these manifests to define the Smart Gateways handling the metrics and the events data for each cloud.
 
 To deploy multiple Smart Gateways, complete the following steps:
 

--- a/doc-Service-Assurance-Framework/modules/proc_querying-metrics-data-from-multiple-clouds.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_querying-metrics-data-from-multiple-clouds.adoc
@@ -24,7 +24,7 @@
 = Querying metrics data from multiple clouds
 
 Data stored in Prometheus has a "service" label attached according to the
-smart gateway it was scraped from. You can use this label to query data from a
+Smart Gateway it was scraped from. You can use this label to query data from a
 specific cloud.
 
 To query data from a specific cloud, use a Prometheus `promql` query that matches the associated "service" label; for example: `sa_collectd_uptime{service="cloud1-smartgateway"}`.

--- a/doc-Service-Assurance-Framework/modules/ref_example-manifests.adoc
+++ b/doc-Service-Assurance-Framework/modules/ref_example-manifests.adoc
@@ -1,0 +1,98 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+// This module can be included from assemblies using the following include statement:
+// include::<path>/ref_example-manifests.adoc[leveloffset=+1]
+
+// The file name and the ID are based on the module title. For example:
+// * file name: ref_my-reference-a.adoc
+// * ID: [id='ref_my-reference-a_{context}']
+// * Title: = My reference A
+//
+// The ID is used as an anchor for linking to the module. Avoid changing
+// it after the module has been published to ensure existing links are not
+// broken.
+//
+// The `context` attribute enables module reuse. Every module's ID includes
+// {context}, which ensures that the module has a unique ID even if it is
+// reused multiple times in a guide.
+//
+// In the title, include nouns that are used in the body text. This helps
+// readers and search engines find information quickly.
+[id="example-manifests_{context}"]
+= Example manifests
+
+[IMPORTANT]
+These content in the following examples might be different to the file content in your deployment. Copy the manifests in your deployment.
+
+Ensure that the `name` and `amqp_url` parameters of each Smart Gateway match the names you want to use for your clouds. For more information, see <<planning-amqp-address-prefixes_connecting-multiple-clouds-to-saf>>.
+
+
+metrics-smartgateway.yaml
+[source, yaml]
+----
+apiVersion: smartgateway.infra.watch/v1alpha1
+kind: SmartGateway
+metadata:
+  name: cloud1-telemetry
+spec:
+  size: 1
+  amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud1-telemetry
+  debug: "false"
+  container_image_path: "docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest"
+  service_type: "metrics"
+
+---
+apiVersion: smartgateway.infra.watch/v1alpha1
+kind: SmartGateway
+metadata:
+  name: cloud2-telemetry
+spec:
+  size: 1
+  amqp_url: qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud2-telemetry
+  debug: "false"
+  container_image_path: "docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest"
+  service_type: "metrics"
+
+----
+
+events-smartgateway.yaml
+[source, yaml]
+----
+---
+apiVersion: smartgateway.infra.watch/v1alpha1
+kind: SmartGateway
+metadata:
+  name: cloud1-notify
+spec:
+  size: 1
+  amqp_url: "qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud1-notify"
+  service_type: events
+  debug: "false"
+  elastic_url: "https://elasticsearch.sa-telemetry.svc:9200"
+  container_image_path: docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest
+  use_tls: "true"
+  tls_client_cert: /config/certs/admin-cert
+  tls_client_key: /config/certs/admin-key
+  tls_ca_cert: /config/certs/admin-ca
+  reset_index: "true"
+
+---
+apiVersion: smartgateway.infra.watch/v1alpha1
+kind: SmartGateway
+metadata:
+  name: cloud2-notify
+spec:
+  size: 1
+  amqp_url: "qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/cloud2-notify"
+  service_type: events
+  debug: "false"
+  elastic_url: "https://elasticsearch.sa-telemetry.svc:9200"
+  container_image_path: docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest
+  use_tls: "true"
+  tls_client_cert: /config/certs/admin-cert
+  tls_client_key: /config/certs/admin-key
+  tls_ca_cert: /config/certs/admin-ca
+  reset_index: "true"
+----

--- a/doc-Service-Assurance-Framework/modules/ref_example-manifests.adoc
+++ b/doc-Service-Assurance-Framework/modules/ref_example-manifests.adoc
@@ -24,12 +24,12 @@
 = Example manifests
 
 [IMPORTANT]
-These content in the following examples might be different to the file content in your deployment. Copy the manifests in your deployment.
+The content in the following examples may be different to the file content in your deployment. Copy the manifests in your deployment.
 
 Ensure that the `name` and `amqp_url` parameters of each Smart Gateway match the names you want to use for your clouds. For more information, see <<planning-amqp-address-prefixes_connecting-multiple-clouds-to-saf>>.
 
 
-metrics-smartgateway.yaml
+.metrics-smartgateway.yaml
 [source, yaml]
 ----
 apiVersion: smartgateway.infra.watch/v1alpha1
@@ -54,10 +54,9 @@ spec:
   debug: "false"
   container_image_path: "docker-registry.default.svc:5000/sa-telemetry/smart-gateway:latest"
   service_type: "metrics"
-
 ----
 
-events-smartgateway.yaml
+.events-smartgateway.yaml
 [source, yaml]
 ----
 ---


### PR DESCRIPTION
* Made this section read like an actual procedure instead of an obscure stand-alone chunk of example yaml
* Made example content actually match current minifests
* Added some specific commands for how to replace any existing smart gateways with new ones

Fixes #1 