### PR TITLE
Drop write prometheus plugin from collectd list

### DIFF
--- a/common/collectd/ref_collectd-plugins.adoc
+++ b/common/collectd/ref_collectd-plugins.adoc
@@ -413,9 +413,6 @@ collectd-write_kafka::
 * collectd::plugin::write_kafka::kafka_hosts
 * collectd::plugin::write_kafka::topics
 
-collectd-write_prometheus::
-* collectd::plugin::write_prometheus::port
-
 collectd-ovs_events::
 * collectd::plugin::ovs_events::address
 * collectd::plugin::ovs_events::dispatch


### PR DESCRIPTION
Write Prometheus plugin is not shipped with Queens/RHOSP13 which is the target of
this documentation, so remove it from the list of plugins.