### PR TITLE
Fixing example collectd config for multi-cloud

### DIFF
--- a/doc-Service-Assurance-Framework/modules/proc_updating-collectd-configuration.adoc
+++ b/doc-Service-Assurance-Framework/modules/proc_updating-collectd-configuration.adoc
@@ -31,11 +31,11 @@ parameter_defaults:
    CollectdAmqpInstances:
        cloud1-telemetry:
            format: JSON
-           presettle: false
+           presettle: true
        cloud1-notify:
            notify: true
            format: JSON
-           presettle: true
+           presettle: false
 ----
 
 For more information on how to edit and redeploy this configuration, see <<configuring-red-hat-openstack-platform-overcloud-for-saf_completing-the-saf-configuration>> and <<updating-red-hat-openstack-platform-overcloud-for-saf_completing-the-saf-configuration>>.


### PR DESCRIPTION
Example presettle settings were backwards. See:  https://review.opendev.org/#/c/692529/1/environments/metrics/collectd-write-qdr.yaml