### PR TITLE
Fix build requirements on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for Red Hat Documentation](https://redhat-documentation.github.io/). This is a
 
 Install required tools. In Fedora perform:
 
-    dnf -y install ruby asciidoctor asciidoctor-pdf make
+    dnf -y install rubygem-asciidoctor rubygem-asciidoctor-pdf make
 
 In MacOS required tools can be installed via brew but instead "make" call
 "gmake":


### PR DESCRIPTION
In Fedora, there is no package asciidoctor-pdf, it is named
rubygem-asciidoctor-pdf. Same for asciidoctor.